### PR TITLE
Update readme.md

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -110,7 +110,7 @@ option to the container to enable it. As an example, using `docker-compose.yaml`
 ```yaml
   ...
   environment:
-    - NTP_SERVER=time.cloudflare.com
+    - NTP_SERVERS=time.cloudflare.com
     - ENABLE_NTS=true
     ...
 ```


### PR DESCRIPTION
Fix typo from `NTP_SERVER` to `NTP_SERVERS` which causes a misunderstanding when configuring the container.