### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ option to the container to enable it. As an example, using `docker-compose.yaml`
 ```yaml
   ...
   environment:
-    - NTP_SERVER=time.cloudflare.com
+    - NTP_SERVERS=time.cloudflare.com
     - ENABLE_NTS=true
     ...
 ```


### PR DESCRIPTION
fix typo from `NTP_SERVER` to `NTP_SERVERS` in order to avoid misconfiguration. (This is for the main README.md)

similar to #11