### PR TITLE
fix: typo in ENABLE_PTP env var in vars file

### DIFF
--- a/vars
+++ b/vars
@@ -30,4 +30,4 @@ LOG_LEVEL=0
 DOCKER_OPTS=""
 
 # (optional) ask run.sh to pass /dev/ptp0
-RENABLE_PTP=false
+ENABLE_PTP=false


### PR DESCRIPTION
Fix (assumed) typo.